### PR TITLE
🐛 [-bug] Addressed issue encountered when attempting to restore dups

### DIFF
--- a/src/FileBackup/Offsite.py
+++ b/src/FileBackup/Offsite.py
@@ -864,9 +864,9 @@ def Restore(
                                         directory_working_dir
                                     )
 
-                                    dest_filename.parent.mkdir(parents=True, exist_ok=True)
-
-                                    os.symlink(fullpath, dest_filename)
+                                    if not dest_filename.is_file():
+                                        dest_filename.parent.mkdir(parents=True, exist_ok=True)
+                                        os.symlink(fullpath, dest_filename)
 
                             # Read the instructions
                             with (directory_working_dir / INDEX_FILENAME).open() as f:


### PR DESCRIPTION
## :pencil: Description
This could happen when restoring 2 files with the same contents from different locations or a file that was backed up, removed, and then later restored.

## :gear: Work Item
N/A

## :movie_camera: Demo
N/A