### PR TITLE
👷 [+ci] Update build scripts to produce working binary

### DIFF
--- a/.github/workflows/CICD_impl.yml
+++ b/.github/workflows/CICD_impl.yml
@@ -66,6 +66,9 @@ jobs:
           python-version: ${{ matrix.python_version }}
           enable-cache: true
 
+      - name: Install Dependencies
+        run: uv sync --frozen
+
       - name: Run pre-commit scripts
         run: uv run pre-commit run --verbose
 
@@ -250,6 +253,9 @@ jobs:
           python-version: ${{ inputs.python_package_version }}
           enable-cache: true
 
+      - name: Install Dependencies
+        run: uv sync --frozen
+
       - name: Build Binary
         run: uv run python BuildBinary.py Build --verbose
 
@@ -261,6 +267,8 @@ jobs:
         with:
           name: Binary.${{ matrix.os }}
           path: FileBackup-${{ env.PACKAGE_VERSION }}.*
+
+  # ----------------------------------------------------------------------
   validate_binary:
     needs: [python_package, build_binary]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ keywords = [
 license = "MIT"
 
 classifiers = [
-    "Development Status :: 4 - Beta",  # TODO
+    "Development Status :: 4 - Beta",
     "Environment :: Console",
     "Intended Audience :: Developers",
     "Intended Audience :: End Users/Desktop",


### PR DESCRIPTION
## :pencil: Description
The updated dependency on `dbrownell_Common` caused an update in `inflect`. The new version of `inflect` introduced a dependency on `typeguard`. `typeguard` introduces code that uses `inspect`, which was failing when compiled with `cx_Freeze` because the python source was not found. This change ensure that inflect's source code is bundled with the binary, which then makes `typeguard` happy. Then, `inflect` is happy, which makes `dbrownell_Common` happy, which makes `FileBackup` work as expected when frozen with `cx_Freeze`.

## :gear: Work Item
N/A

## :movie_camera: Demo
N/A